### PR TITLE
Add optional support for full OAuth workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,34 @@ git clone git@github.com:scottrobertson/monzo-to-qif.git
 bundle
 ```
 
-### Run
+### Quick Start
 
 ```
 MONZO=token from https://developers.monzo.com/
 ruby monzo-to-qif.rb generate --access_token=$MONZO --since=2016-10-10 --folder=/path/to/folder
 ```
+
+### OAuth Configuration
+
+This allows you to use a token from a client you set up on `https://developers.monzo.com/` and then omit the `--access_token` argument.
+
+Create a new client (either confidential or non-confidential) with a redirect url of `http://localhost/monzotoqif/` and then make a note of the `clientID` and `clientSecret`.
+
+To configure Monzo To QIF to use OAuth, first run
+```
+ruby monzo-to-qif.rb auth --clientid {clientID} --clientsecret {clientSecret}
+```
+
+This will prompt you to browse to the Monzo auth url in your browser to obtain your authorization code. Completing this workflow will result in Monzo sending you an email with a login link. You need to copy this link and use it in the next command.
+```
+ruby monzo-to-qif auth --authurl {link-from-email}
+```
+
+This completes the setup, retrieves and stores the access token.
+
+#### Differences between Confidential and Non-confidential clients
+
+- A confidential client will also give you a refresh token which is automatically used when your access token expires without any further input.
+- A non-confidential client will prompt the user to re-authenticate whenever the access token expires.
+
+The tokens are stored locally in `config.yml` so anyone with access to this folder also has access to your access/refresh tokens.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ MONZO=token from https://developers.monzo.com/
 ruby monzo-to-qif.rb generate --access_token=$MONZO --since=2016-10-10 --folder=/path/to/folder
 ```
 
+#### Quick Start Current Account
+
+```
+MONZO=token from https://developers.monzo.com/
+ruby monzo-to-qif.rb generate --access_token=$MONZO --since=2016-10-10 --folder=/path/to/folder --current_account
+```
+
 ### OAuth Configuration
 
 This allows you to use a token from a client you set up on `https://developers.monzo.com/` and then omit the `--access_token` argument.

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,1 @@
+user_data: 'hello world'

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -1,0 +1,60 @@
+require 'yaml'
+require 'rest-client'
+
+class OAuth
+
+  def initialize()
+    @redirectURI = 'http://localhost/monzotoqif/'
+    @config = YAML.load_file('config.yml')
+  end
+  
+  def getAccessToken()
+	if !@config['access_token']
+	  puts 'Authorization token not configured'
+    end
+	if Time.now > @config['expiry']
+	  refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])
+	end
+	@config['access_token']
+  end
+  
+  def initialAuth(clientId, clientSecret)
+    @config['clientId'] = clientId
+	@config['clientSecret'] = clientSecret
+	@config['state'] = SecureRandom.urlsafe_base64(64)
+	saveConfig()
+    say "Open the following URL in a browser:"
+    say "https://auth.getmondo.co.uk/?client_id=#{clientId}&redirect_uri=#{@redirectURI}&response_type=code&state=#{@config['state']}"
+  end
+  
+  def processAuthUrl(authCode, state)
+    if state != @config['state']
+	  say "Invalid callback state"
+	 else
+	   exchangeAuthCode(@config['clientId'], @config['clientSecret'], @redirectURI, authCode)
+	   say "Access token retrieved"
+	 end
+  end
+  
+  def exchangeAuthCode(clientId, clientSecret, redirectURI, authCode)
+	json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'authorization_code', client_id: @config['clientId'], client_secret: @config['clientSecret'], redirect_uri: @redirectURI, code: authCode}))
+	@config['access_token'] = json['access_token']
+	@config['refresh_token'] = json['refresh_token']
+	@config['expiry'] = Time.now + json['expires_in'] - 120
+	@config['state'] = ''
+	saveConfig
+  end
+  
+  def refreshToken(clientId, clientSecret, refreshToken)
+	json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'refresh_token', client_id: @config['clientId'], client_secret: @config['clientSecret'], refresh_token: refreshToken}))
+	@config['access_token'] = json['access_token']
+	@config['refresh_token'] = json['refresh_token']
+	@config['expiry'] = Time.now + json['expires_in']
+	@config['state'] = ''
+	saveConfig()
+  end
+  
+  def saveConfig()
+    File.write('config.yml', @config.to_yaml)
+  end
+end

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -10,7 +10,7 @@ class OAuth
   
   def getAccessToken()
 	if !@config['access_token']
-	  puts 'Authorization token not configured'
+	  puts 'OAuth not configured. Please run Monzo to QIF auth.'
     end
 	if Time.now > @config['expiry']
 	  refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -10,10 +10,16 @@ class OAuth
   
   def getAccessToken()
 	if !@config['access_token']
-	  puts 'OAuth not configured. Please run Monzo to QIF auth.'
+	  say 'OAuth not configured. Please run Monzo to QIF auth'
+	  abort
     end
 	if Time.now > @config['expiry']
-	  refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])
+	  if @config['refresh_token']
+	    refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])
+	  else
+	    say 'Existing token has expired, please re-authenticate.'
+	    initialAuth(@config['clientId'], @config['clientSecret'])
+	  end
 	end
 	@config['access_token']
   end
@@ -23,23 +29,26 @@ class OAuth
 	@config['clientSecret'] = clientSecret
 	@config['state'] = SecureRandom.urlsafe_base64(64)
 	saveConfig()
-    say "Open the following URL in a browser:"
+    say "Open the following URL in a browser and follow the instructions. When you recieve the response email, copy the url and pass it to the --authurl parameter"
     say "https://auth.getmondo.co.uk/?client_id=#{clientId}&redirect_uri=#{@redirectURI}&response_type=code&state=#{@config['state']}"
   end
   
   def processAuthUrl(authCode, state)
     if state != @config['state']
-	  say "Invalid callback state"
+	  say "Auth url state does not match internal state. Try setting up OAuth again."
+	  abort
 	 else
 	   exchangeAuthCode(@config['clientId'], @config['clientSecret'], @redirectURI, authCode)
-	   say "Access token retrieved"
 	 end
   end
   
   def exchangeAuthCode(clientId, clientSecret, redirectURI, authCode)
 	json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'authorization_code', client_id: @config['clientId'], client_secret: @config['clientSecret'], redirect_uri: @redirectURI, code: authCode}))
 	@config['access_token'] = json['access_token']
-	@config['refresh_token'] = json['refresh_token']
+	# non-confidential clients won't return a refresh token
+	if json['refresh_token']
+      @config['refresh_token'] = json['refresh_token']
+	end
 	@config['expiry'] = Time.now + json['expires_in'] - 120
 	@config['state'] = ''
 	saveConfig

--- a/lib/oauth.rb
+++ b/lib/oauth.rb
@@ -9,58 +9,58 @@ class OAuth
   end
   
   def getAccessToken()
-	if !@config['access_token']
-	  say 'OAuth not configured. Please run Monzo to QIF auth'
-	  abort
+    if !@config['access_token']
+      say 'OAuth not configured. Please run Monzo to QIF auth'
+      abort
     end
-	if Time.now > @config['expiry']
-	  if @config['refresh_token']
-	    refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])
-	  else
-	    say 'Existing token has expired, please re-authenticate.'
-	    initialAuth(@config['clientId'], @config['clientSecret'])
-	  end
-	end
-	@config['access_token']
+    if Time.now > @config['expiry']
+      if @config['refresh_token']
+        refreshToken(@config['clientId'], @config['clientSecret'], @config['refresh_token'])
+      else
+        say 'Existing token has expired, please re-authenticate.'
+        initialAuth(@config['clientId'], @config['clientSecret'])
+      end
+    end
+    @config['access_token']
   end
   
   def initialAuth(clientId, clientSecret)
     @config['clientId'] = clientId
-	@config['clientSecret'] = clientSecret
-	@config['state'] = SecureRandom.urlsafe_base64(64)
-	saveConfig()
+    @config['clientSecret'] = clientSecret
+    @config['state'] = SecureRandom.urlsafe_base64(64)
+    saveConfig()
     say "Open the following URL in a browser and follow the instructions. When you recieve the response email, copy the url and pass it to the --authurl parameter"
     say "https://auth.getmondo.co.uk/?client_id=#{clientId}&redirect_uri=#{@redirectURI}&response_type=code&state=#{@config['state']}"
   end
   
   def processAuthUrl(authCode, state)
     if state != @config['state']
-	  say "Auth url state does not match internal state. Try setting up OAuth again."
-	  abort
-	 else
-	   exchangeAuthCode(@config['clientId'], @config['clientSecret'], @redirectURI, authCode)
-	 end
+      say "Auth url state does not match internal state. Try setting up OAuth again."
+      abort
+    else
+      exchangeAuthCode(@config['clientId'], @config['clientSecret'], @redirectURI, authCode)
+    end
   end
   
   def exchangeAuthCode(clientId, clientSecret, redirectURI, authCode)
-	json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'authorization_code', client_id: @config['clientId'], client_secret: @config['clientSecret'], redirect_uri: @redirectURI, code: authCode}))
-	@config['access_token'] = json['access_token']
-	# non-confidential clients won't return a refresh token
-	if json['refresh_token']
+    json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'authorization_code', client_id: @config['clientId'], client_secret: @config['clientSecret'], redirect_uri: @redirectURI, code: authCode}))
+    @config['access_token'] = json['access_token']
+    # non-confidential clients won't return a refresh token
+    if json['refresh_token']
       @config['refresh_token'] = json['refresh_token']
-	end
-	@config['expiry'] = Time.now + json['expires_in'] - 120
-	@config['state'] = ''
-	saveConfig
+    end
+    @config['expiry'] = Time.now + json['expires_in'] - 120
+    @config['state'] = ''
+    saveConfig
   end
   
   def refreshToken(clientId, clientSecret, refreshToken)
-	json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'refresh_token', client_id: @config['clientId'], client_secret: @config['clientSecret'], refresh_token: refreshToken}))
-	@config['access_token'] = json['access_token']
-	@config['refresh_token'] = json['refresh_token']
-	@config['expiry'] = Time.now + json['expires_in']
-	@config['state'] = ''
-	saveConfig()
+    json = JSON.parse(RestClient.post("https://api.monzo.com/oauth2/token", {grant_type: 'refresh_token', client_id: @config['clientId'], client_secret: @config['clientSecret'], refresh_token: refreshToken}))
+    @config['access_token'] = json['access_token']
+    @config['refresh_token'] = json['refresh_token']
+    @config['expiry'] = Time.now + json['expires_in']
+    @config['state'] = ''
+    saveConfig()
   end
   
   def saveConfig()

--- a/monzo-to-qif.rb
+++ b/monzo-to-qif.rb
@@ -22,15 +22,15 @@ command :generate do |c|
   c.option '--current_account', String, 'Export transactions from the current account instead of the prepaid account'
   c.action do |args, options|
     since = options.since ? Date.parse(options.since).to_time : (Time.now - (60*60*24*14)).to_date
-	
+
     if options.access_token
-	  accessToken = options.access_token
-	else
-	  auth = OAuth.new()
-	  accessToken = auth.getAccessToken()
-	end
-	
-	fetcher = TransactionFetcher.new(accessToken, current_account: options.current_account)
+      accessToken = options.access_token
+    else
+      auth = OAuth.new()
+      accessToken = auth.getAccessToken()
+    end
+
+    fetcher = TransactionFetcher.new(accessToken, current_account: options.current_account)
     qif = QifCreator.new(fetcher.fetch(since: since)).create(options.folder, settled_only: options.settled_only, account_number: (fetcher.account_number || 'prepaid'))
 
     if options.current_account
@@ -51,22 +51,22 @@ command :auth do |c|
   c.option '--authurl URL', String, 'The authorization URL you received when you authorized Monzo to QIF from: https://developers.monzo.com/ you will need to enclose the URL in doubl quotes'
   c.action do |args, options|
     if options.clientid && options.clientsecret && !options.authurl
-	  auth = OAuth.new().initialAuth(options.clientid, options.clientsecret)
-	else 
-	  if options.authurl && !options.clientid && !options.clientsecret
-	    urlParams = CGI.parse(URI.parse(options.authurl).query)
-	    if !urlParams['code'][0]
-	      say "Badly formatted URL. Missing the code parameter"
-		  abort
-	    end
-	    if !urlParams['state'][0]
-	      say "Badly formatted URL. Missing the state parameter"
-		  abort
-	    end
-	    auth = OAuth.new().processAuthUrl(urlParams['code'][0], urlParams['state'][0])
-	  else
-	    say "Invalid combination of arguments. Use either [--authurl] OR [--clientid AND --clientsecret]"
-	  end
-    end	  
+      auth = OAuth.new().initialAuth(options.clientid, options.clientsecret)
+    else 
+      if options.authurl && !options.clientid && !options.clientsecret
+        urlParams = CGI.parse(URI.parse(options.authurl).query)
+        if !urlParams['code'][0]
+          say "Badly formatted URL. Missing the code parameter"
+          abort
+        end
+        if !urlParams['state'][0]
+          say "Badly formatted URL. Missing the state parameter"
+          abort
+        end
+        auth = OAuth.new().processAuthUrl(urlParams['code'][0], urlParams['state'][0])
+      else
+        say "Invalid combination of arguments. Use either [--authurl] OR [--clientid AND --clientsecret]"
+      end
+    end
   end
 end

--- a/monzo-to-qif.rb
+++ b/monzo-to-qif.rb
@@ -15,14 +15,22 @@ command :generate do |c|
   c.syntax = 'Monzo to QIF generate [options]'
   c.summary = 'Generate the QIF file'
   c.description = ''
+  c.option '--access_token TOKEN', String, 'Your access token from: https://developers.monzo.com/'
   c.option '--since DATE', String, 'The date (YYYY-MM-DD) to start exporting transactions from. Defaults to 2 weeks ago'
   c.option '--folder PATH', String, 'The folder to export to. Defaults to ./exports'
   c.option '--settled_only', String, 'Only export settled transactions'
   c.option '--current_account', String, 'Export transactions from the current account instead of the prepaid account'
   c.action do |args, options|
     since = options.since ? Date.parse(options.since).to_time : (Time.now - (60*60*24*14)).to_date
-    auth = OAuth.new()
-	fetcher = TransactionFetcher.new(auth.getAccessToken(), current_account: options.current_account)
+	
+    if options.access_token
+	  accessToken = options.access_token
+	else
+	  auth = OAuth.new()
+	  accessToken = auth.getAccessToken()
+	end
+	
+	fetcher = TransactionFetcher.new(accessToken, current_account: options.current_account)
     qif = QifCreator.new(fetcher.fetch(since: since)).create(options.folder, settled_only: options.settled_only, account_number: (fetcher.account_number || 'prepaid'))
 
     if options.current_account

--- a/monzo-to-qif.rb
+++ b/monzo-to-qif.rb
@@ -5,10 +5,7 @@ require 'commander/import'
 require 'colorize'
 require_relative 'lib/transaction_fetcher'
 require_relative 'lib/qif_creator'
-require 'yaml'
-
-config = YAML.load_file('config.yml')
-puts config['user_data']
+require_relative 'lib/oauth'
 
 program :name, 'Monzo to QIF'
 program :version, '0.0.1'
@@ -18,36 +15,39 @@ command :generate do |c|
   c.syntax = 'Monzo to QIF generate [options]'
   c.summary = 'Generate the QIF file'
   c.description = ''
-  c.option '--access_token TOKEN', String, 'Your access token from: https://developers.monzo.com/'
   c.option '--since DATE', String, 'The date (YYYY-MM-DD) to start exporting transactions from. Defaults to 2 weeks ago'
   c.option '--folder PATH', String, 'The folder to export to. Defaults to ./exports'
   c.option '--settled_only', String, 'Only export settled transactions'
   c.option '--current_account', String, 'Export transactions from the current account instead of the prepaid account'
   c.action do |args, options|
     since = options.since ? Date.parse(options.since).to_time : (Time.now - (60*60*24*14)).to_date
-    if options.access_token
-      fetcher = TransactionFetcher.new(options.access_token, current_account: options.current_account)
-      qif = QifCreator.new(fetcher.fetch(since: since)).create(options.folder, settled_only: options.settled_only, account_number: (fetcher.account_number || 'prepaid'))
+    auth = OAuth.new()
+	fetcher = TransactionFetcher.new(auth.getAccessToken(), current_account: options.current_account)
+    qif = QifCreator.new(fetcher.fetch(since: since)).create(options.folder, settled_only: options.settled_only, account_number: (fetcher.account_number || 'prepaid'))
 
-      if options.current_account
-        say "Account Number: #{fetcher.account_number}"
-        say "Sort Code: #{fetcher.sort_code}"
-      end
-
-      say "Balance: £#{fetcher.balance}"
-    else
-      say 'Please supply an access_token'
+    if options.current_account
+      say "Account Number: #{fetcher.account_number}"
+      say "Sort Code: #{fetcher.sort_code}"
     end
+
+    say "Balance: £#{fetcher.balance}"
   end
 end
 
 command :auth do |c|
   c.syntax = 'Monzo to QIF auth [options]'
   c.summary = 'Configure OAuth for passwordless/tokenless login'
-  c.description = ''
+  c.description = 'This is a 2 step authorization process. Step 1 configures the client and requests an auth code from monzo. Step 2 exchanges the auth code for an auth and refresh token. First run Monzo to QIF auth --clientid ID --clientsecret ID and follow the instructions. Secondly paste the url from the login email as the argument to Monzo to QIF auth --authurl URL'
   c.option '--clientid ID', String, 'Your confidential client ID from: https://developers.monzo.com/'
   c.option '--clientsecret ID', String, 'Your confidential client secret from: https://developers.monzo.com/'
-  c.option '--authurl URL', String 'The authorization URL you received when you authorized Monzo to QIF from: https://developers.monzo.com/'
+  c.option '--authurl URL', String, 'The authorization URL you received when you authorized Monzo to QIF from: https://developers.monzo.com/ you will need to escape the & character in the url'
   c.action do |args, options|
+    if options.clientid && options.clientsecret
+	  auth = OAuth.new().initialAuth(options.clientid, options.clientsecret)
+	end
+	if options.authurl
+	  urlParams = CGI.parse(URI.parse(options.authurl).query)
+	  auth = OAuth.new().processAuthUrl(urlParams['code'][0], urlParams['state'][0])
+	end
   end
 end

--- a/monzo-to-qif.rb
+++ b/monzo-to-qif.rb
@@ -40,3 +40,14 @@ command :generate do |c|
     end
   end
 end
+
+command :auth do |c|
+  c.syntax = 'Monzo to QIF auth [options]'
+  c.summary = 'Configure OAuth for passwordless/tokenless login'
+  c.description = ''
+  c.option '--clientid ID', String, 'Your confidential client ID from: https://developers.monzo.com/'
+  c.option '--clientsecret ID', String, 'Your confidential client secret from: https://developers.monzo.com/'
+  c.option '--authurl URL', String 'The authorization URL you received when you authorized Monzo to QIF from: https://developers.monzo.com/'
+  c.action do |args, options|
+  end
+end

--- a/monzo-to-qif.rb
+++ b/monzo-to-qif.rb
@@ -5,6 +5,10 @@ require 'commander/import'
 require 'colorize'
 require_relative 'lib/transaction_fetcher'
 require_relative 'lib/qif_creator'
+require 'yaml'
+
+config = YAML.load_file('config.yml')
+puts config['user_data']
 
 program :name, 'Monzo to QIF'
 program :version, '0.0.1'


### PR DESCRIPTION
Hi Scott,

I've just added a rough and ready OAuth workflow that allows monzo-to-qif to act as a "proper" client using its own tokens.

I wrote this mainly so I could automate running of the script without having to grab a token from the dev portal, so it supports confidential and non-confidential clients.
A confidential client makes running the script painless as it never requires any further authorization, and a non-confidential client just simplifies grabbing a token.

Feel free to reject if you don't want this in the codebase.