### PR TITLE
Prevent the fees kvp from breaking parsing

### DIFF
--- a/lib/transaction_fetcher.rb
+++ b/lib/transaction_fetcher.rb
@@ -13,6 +13,8 @@ class TransactionFetcher
 
   def fetch(since: (Time.now - (60*60*24*14)).to_date)
     transactions = http_get("/transactions?account_id=#{@account_id}&since=#{since.strftime('%FT%TZ')}&expand[]=merchant")
+    # delete the fees children as they contain an unparsable key (withdrawal.atm.international)
+    transactions['transactions'].each {|x| x.delete_if {|y| y == "fees"}}
     transactions['transactions'].map{|t| OmniStruct.new(t)}
   end
 


### PR DESCRIPTION
The fees key can contain a kvp with an invalid key (contains periods instead of underscores). This PR just removes the fees key entirely before parsing.

The monzo developers have noted that inclusion of the fees key in some transactions is a bug, and also that the periods are unfortunate but won't be fixed in the near future as the current apps expect them.